### PR TITLE
Google Vision API Demo

### DIFF
--- a/GeminiApp/VisionAPI_Demo.py
+++ b/GeminiApp/VisionAPI_Demo.py
@@ -1,0 +1,8 @@
+import os
+import io
+from google.cloud import vision
+from google.cloud.vision import types
+
+os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = r'perfect-age-294000-e8cefcdf70dd.json'
+
+client = vision.ImageAnnotatorClient()


### PR DESCRIPTION
From the following Youtube Tutorial: https://youtu.be/xKvffLRSyPk , Part 2: Configuration and Setup.
Has issues with 'from google.cloud.vision import types'
Error says: "ImportError: cannot import name 'types' from 'google.cloud.vision' (/Users/rachelbang/PycharmProjects/testingHelloWorld/venv/lib/python3.8/site-packages/google/cloud/vision/__init__.py)"